### PR TITLE
After click on group in the grid, the urls did not load automatically. Fixed now.

### DIFF
--- a/frontend/src/app/Components/MainPages/main-page/main-page.component.ts
+++ b/frontend/src/app/Components/MainPages/main-page/main-page.component.ts
@@ -86,6 +86,7 @@ export class MainPageComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    this.retrieveAllShortURLsByGroupName();
   }
 
   retrieveAllShortURLsByGroupName(): void {

--- a/frontend/src/app/Components/TopBarComponents/group-selection/group-selection.component.html
+++ b/frontend/src/app/Components/TopBarComponents/group-selection/group-selection.component.html
@@ -1,3 +1,3 @@
-<select [(ngModel)]="this.getDBConnector().activeGroup">
+<select [(ngModel)]="this.getDBConnector().activeGroup" (ngModelChange)="this.refreshWebApp()">
   <option *ngFor="let group of this.groups;" [value]="group">{{group}}</option>
 </select>

--- a/frontend/src/app/Components/TopBarComponents/group-selection/group-selection.component.html
+++ b/frontend/src/app/Components/TopBarComponents/group-selection/group-selection.component.html
@@ -1,3 +1,3 @@
-<select [(ngModel)]="this.getDBConnector().activeGroup" (ngModelChange)="this.refreshWebApp()">
+<select [(ngModel)]="this.getDBConnector().activeGroup" (ngModelChange)="this.reloadMainPage()">
   <option *ngFor="let group of this.groups;" [value]="group">{{group}}</option>
 </select>

--- a/frontend/src/app/Components/TopBarComponents/group-selection/group-selection.component.ts
+++ b/frontend/src/app/Components/TopBarComponents/group-selection/group-selection.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import {DbConnectorService} from '../../../Services/DB-Connect-Services/db-connector.service';
+import {Router} from '@angular/router';
 
 @Component({
   selector: 'app-user-selection',
@@ -10,7 +11,7 @@ export class GroupSelectionComponent implements OnInit {
 
   groups: string[] = [];
 
-  constructor(private dbconnector: DbConnectorService) { }
+  constructor(private dbconnector: DbConnectorService, protected router: Router) { }
 
   ngOnInit(): void {
     this.retrieveAllGroupsOfUser();
@@ -25,4 +26,11 @@ export class GroupSelectionComponent implements OnInit {
   public getDBConnector(): DbConnectorService {
     return this.dbconnector;
   }
+
+  public refreshWebApp(): void {
+    this.router. navigateByUrl('/main', { skipLocationChange: true }).then(() => {
+      this.router.navigate(['main']);
+    });
+  }
+
 }

--- a/frontend/src/app/Components/TopBarComponents/group-selection/group-selection.component.ts
+++ b/frontend/src/app/Components/TopBarComponents/group-selection/group-selection.component.ts
@@ -27,7 +27,7 @@ export class GroupSelectionComponent implements OnInit {
     return this.dbconnector;
   }
 
-  public refreshWebApp(): void {
+  public reloadMainPage(): void {
     this.router. navigateByUrl('/main', { skipLocationChange: true }).then(() => {
       this.router.navigate(['main']);
     });


### PR DESCRIPTION
… anymore. Fix: call retrieveAllShortURLsByGroupName in OnInit of the main-page. Now it works.